### PR TITLE
Add files array to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,10 @@
     "watch": "tsc --watch --declaration",
     "test": "ts-node node_modules/tape/bin/tape ./tests/index.ts"
   },
+  "files": [
+    "lib/",
+    "src/"
+  ],
   "dependencies": {
     "apache-arrow": "^12.0.0"
   },


### PR DESCRIPTION
Set `files` in `package.json` to include correct source files.

Before: `npm pack` was ignoring `lib/` (because it's git ignored) and including everything in tests.

After:
```
npm notice 1.1kB  LICENSE
npm notice 6.8kB  lib/field.js
npm notice 78B    lib/index.js
npm notice 13.2kB lib/vector.js
npm notice 756B   package.json
npm notice 4.3kB  README.md
npm notice 590B   lib/field.d.ts
npm notice 6.8kB  src/field.ts
npm notice 78B    lib/index.d.ts
npm notice 78B    src/index.ts
npm notice 1.3kB  lib/vector.d.ts
npm notice 12.7kB src/vector.ts
```