### PR TITLE
WIP: nanoarrow refactor

### DIFF
--- a/src/arrow/README.md
+++ b/src/arrow/README.md
@@ -1,0 +1,1 @@
+Conversions to and from Arrow JS objects from the bare "nanoarrow" objects.

--- a/src/arrow/array/read.ts
+++ b/src/arrow/array/read.ts
@@ -1,0 +1,159 @@
+import * as arrow from "apache-arrow";
+import { ArrowArray } from "../../nanoarrow";
+import { assert } from "../../vector";
+
+export function readArrayArrowJS(data: arrow.Data): ArrowArray {
+  const nanoarrowChildren: ArrowArray[] = [];
+  for (const arrowJsChild of data.children) {
+    const nanoarrowChild = readArrayArrowJS(arrowJsChild);
+    nanoarrowChildren.push(nanoarrowChild);
+  }
+
+  let nanoarrowDictionary: ArrowArray | null = null;
+  if (data.dictionary) {
+    const dictionaryVector = data.dictionary;
+    assert(dictionaryVector.data.length === 1);
+    nanoarrowDictionary = readArrayArrowJS(dictionaryVector.data[0]);
+  }
+
+  const buffers = constructNanoarrowBuffers(data);
+
+  return {
+    length: data.length,
+    nullCount: data.nullCount,
+    offset: data.offset,
+    buffers,
+    children: nanoarrowChildren,
+    dictionary: nanoarrowDictionary,
+  };
+}
+
+function constructNanoarrowBuffers(data: arrow.Data): (Uint8Array | null)[] {
+  switch (data.type.typeId) {
+    // Null type has no buffers
+    case arrow.Type.Null:
+      return [];
+
+    // Primitive type has two buffers: validity and data
+    case arrow.Type.Int:
+    case arrow.Type.Float:
+    case arrow.Type.Bool:
+    case arrow.Type.Decimal:
+    case arrow.Type.Date:
+    case arrow.Type.Time:
+    case arrow.Type.Timestamp:
+    case arrow.Type.Interval:
+    case arrow.Type.Int8:
+    case arrow.Type.Int16:
+    case arrow.Type.Int32:
+    case arrow.Type.Int64:
+    case arrow.Type.Uint8:
+    case arrow.Type.Uint16:
+    case arrow.Type.Uint32:
+    case arrow.Type.Uint64:
+    case arrow.Type.Float16:
+    case arrow.Type.Float32:
+    case arrow.Type.Float64:
+    case arrow.Type.DateDay:
+    case arrow.Type.DateMillisecond:
+    case arrow.Type.TimestampSecond:
+    case arrow.Type.TimestampMillisecond:
+    case arrow.Type.TimestampMicrosecond:
+    case arrow.Type.TimestampNanosecond:
+    case arrow.Type.TimeSecond:
+    case arrow.Type.TimeMillisecond:
+    case arrow.Type.TimeMicrosecond:
+    case arrow.Type.TimeNanosecond:
+    case arrow.Type.IntervalDayTime:
+    case arrow.Type.IntervalYearMonth: {
+      const validity = data.nullBitmap;
+      const values = data.values;
+      const uint8Values = new Uint8Array(
+        values.buffer,
+        values.buffer.byteOffset,
+        values.buffer.byteLength
+      );
+      return [validity, uint8Values];
+    }
+
+    // Variable binary has three buffers: validity, offsets, data
+    case arrow.Type.Binary: {
+      const validity = data.nullBitmap;
+      const offsets = data.valueOffsets;
+      const uint8Offsets = new Uint8Array(
+        offsets.buffer,
+        // @ts-expect-error Property 'byteOffset' does not exist on type 'ArrayBufferLike'.
+        offsets.buffer.byteOffset || 0,
+        offsets.buffer.byteLength
+      );
+      const values = data.values;
+      const uint8Values = new Uint8Array(
+        values.buffer,
+        values.buffer.byteOffset,
+        values.buffer.byteLength
+      );
+      return [validity, uint8Offsets, uint8Values];
+    }
+
+    // List has two buffers: validity and offsets
+    case arrow.Type.List:
+    case arrow.Type.Utf8: {
+      const validity = data.nullBitmap;
+      const offsets = data.valueOffsets;
+      const uint8Offsets = new Uint8Array(
+        offsets.buffer,
+        // @ts-expect-error Property 'byteOffset' does not exist on type 'ArrayBufferLike'.
+        offsets.buffer.byteOffset || 0,
+        offsets.buffer.byteLength
+      );
+      return [validity, uint8Offsets];
+    }
+
+    // Fixed-size List, Fixed-size Binary, Struct have one buffer: validity
+    case arrow.Type.FixedSizeList:
+    case arrow.Type.FixedSizeBinary:
+    case arrow.Type.Struct:
+      return [data.nullBitmap];
+
+    // Sparse Union has one buffer: type ids
+    case arrow.Type.SparseUnion: {
+      const typeIds = data.typeIds;
+      const uint8TypeIds = new Uint8Array(
+        typeIds.buffer,
+        typeIds.buffer.byteOffset || 0,
+        typeIds.buffer.byteLength
+      );
+      return [uint8TypeIds];
+    }
+
+    // Dense Union has two buffers: type ids and offsets
+    case arrow.Type.DenseUnion: {
+      const typeIds = data.typeIds;
+      const uint8TypeIds = new Uint8Array(
+        typeIds.buffer,
+        typeIds.buffer.byteOffset || 0,
+        typeIds.buffer.byteLength
+      );
+      const offsets = data.valueOffsets;
+      const uint8Offsets = new Uint8Array(
+        offsets.buffer,
+        // @ts-expect-error Property 'byteOffset' does not exist on type 'ArrayBufferLike'.
+        offsets.buffer.byteOffset || 0,
+        offsets.buffer.byteLength
+      );
+      return [uint8TypeIds, uint8Offsets];
+    }
+
+    case arrow.Type.Union: {
+      // TODO:
+      assert(false);
+    }
+
+    default:
+      break;
+  }
+
+  assert(false);
+  // @ts-expect-error
+  return;
+}

--- a/src/arrow/schema/write.ts
+++ b/src/arrow/schema/write.ts
@@ -1,0 +1,22 @@
+// Convert a nanoarrow `ArrowSchema` to an Arrow JS Field
+
+import { ArrowSchema } from "../../nanoarrow";
+import * as arrow from "apache-arrow";
+
+/**
+ * Convert an `ArrowSchema` object into an Arrow JS Field
+ *
+ * - `schema`: The `ArrowSchema` object to convert.
+ *
+ * @return An Arrow JS Field.
+ */
+export function convertSchemaToArrowJS(schema: ArrowSchema): arrow.Field {
+  const type = convertFormatStringToDataType(schema.format);
+  const nullable = true;
+  const metadata = new Map();
+  return new arrow.Field(schema.name, type, nullable, metadata);
+}
+
+function convertFormatStringToDataType(format: string): arrow.DataType {
+  return new arrow.Uint16();
+}

--- a/src/ffi/array.ts
+++ b/src/ffi/array.ts
@@ -1,33 +1,25 @@
 import * as arrow from "apache-arrow";
 import { DataType } from "apache-arrow";
-import { LargeList, isLargeBinary, isLargeList, isLargeUtf8 } from "./types";
+import { ArrowArray, ArrowSchema } from "../nanoarrow";
+// import { LargeList, isLargeBinary, isLargeList, isLargeUtf8 } from "./types";
 
 type NullBitmap = Uint8Array | null | undefined;
 
 /**
-Parse an [`ArrowArray`](https://arrow.apache.org/docs/format/CDataInterface.html#the-arrowarray-structure) C FFI struct into an [`arrow.Vector`](https://arrow.apache.org/docs/js/classes/Arrow_dom.Vector.html) instance. Multiple `Vector` instances can be joined to make an [`arrow.Table`](https://arrow.apache.org/docs/js/classes/Arrow_dom.Table.html).
-
-- `buffer` (`ArrayBuffer`): The [`WebAssembly.Memory`](https://developer.mozilla.org/en-US/docs/WebAssembly/JavaScript_interface/Memory) instance to read from.
-- `ptr` (`number`): The numeric pointer in `buffer` where the C struct is located.
-- `dataType` (`arrow.DataType`): The type of the vector to parse. This is retrieved from `field.type` on the result of `parseField`.
-- `copy` (`boolean`): If `true`, will _copy_ data across the Wasm boundary, allowing you to delete the copy on the Wasm side. If `false`, the resulting `arrow.Vector` objects will be _views_ on Wasm memory. This requires careful usage as the arrays will become invalid if the memory region in Wasm changes.
+ * Parse an [`ArrowArray`](https://arrow.apache.org/docs/format/CDataInterface.html#the-arrowarray-structure) C FFI struct into an `ArrowArray` instance.
+ *
+ * - `buffer` (`ArrayBuffer`): The [`WebAssembly.Memory`](https://developer.mozilla.org/en-US/docs/WebAssembly/JavaScript_interface/Memory) instance to read from.
+ * - `ptr` (`number`): The numeric pointer in `buffer` where the C struct is located.
+ * - `dataType` (`arrow.DataType`): The type of the vector to parse. This is retrieved from `field.type` on the result of `parseField`.
+ * - `copy` (`boolean`): If `true`, will _copy_ data across the Wasm boundary, allowing you to delete the copy on the Wasm side. If `false`, the resulting `arrow.Vector` objects will be _views_ on Wasm memory. This requires careful usage as the arrays will become invalid if the memory region in Wasm changes.
+ *
  */
-export function parseVector<T extends DataType>(
+export function parseArrowArray<T extends DataType>(
   buffer: ArrayBuffer,
   ptr: number,
-  dataType: T,
+  schema: ArrowSchema,
   copy: boolean = false
-): arrow.Vector<T> {
-  const data = parseData(buffer, ptr, dataType, copy);
-  return arrow.makeVector(data);
-}
-
-export function parseData<T extends DataType>(
-  buffer: ArrayBuffer,
-  ptr: number,
-  dataType: T,
-  copy: boolean = false
-): arrow.Data<T> {
+): ArrowArray {
   const dataView = new DataView(buffer);
 
   const length = Number(dataView.getBigInt64(ptr, true));
@@ -44,14 +36,21 @@ export function parseData<T extends DataType>(
   }
 
   const ptrToChildrenPtrs = dataView.getUint32(ptr + 44, true);
-  const children: arrow.Vector[] = new Array(Number(nChildren));
+  const children: ArrowArray[] = new Array(Number(nChildren));
   for (let i = 0; i < nChildren; i++) {
-    children[i] = parseVector(
+    children[i] = parseArrowArray(
       buffer,
       dataView.getUint32(ptrToChildrenPtrs + i * 4, true),
-      dataType.children[i].type,
+      schema.children[i],
       copy
     );
+  }
+
+
+  return {
+    length,
+    nullCount,
+    offset,
   }
 
   if (DataType.isNull(dataType)) {

--- a/src/ffi/array/index.ts
+++ b/src/ffi/array/index.ts
@@ -1,0 +1,2 @@
+export { readArrayFFI } from "./read";
+export { writeArrayFFI } from "./write";

--- a/src/ffi/array/read.ts
+++ b/src/ffi/array/read.ts
@@ -1,5 +1,5 @@
-import { ArrowArray, ArrowSchema } from "../nanoarrow";
-import { ArrowStaticType } from "../nanoarrow/schema";
+import type { ArrowArray, ArrowSchema } from "../../nanoarrow";
+import { ArrowStaticType } from "../../nanoarrow/schema";
 
 const PRIMITIVE_DATA_TYPES: string[] = [
   ArrowStaticType.Bool,
@@ -36,15 +36,15 @@ const VARIABLE_BINARY_STRING_DATA_TYPES: string[] = [
 ];
 
 /**
- * Parse an [`ArrowArray`](https://arrow.apache.org/docs/format/CDataInterface.html#the-arrowarray-structure) C FFI struct into an `ArrowArray` instance.
+ * Read an [`ArrowArray`](https://arrow.apache.org/docs/format/CDataInterface.html#the-arrowarray-structure) C FFI struct into an `ArrowArray` instance.
  *
  * - `buffer` (`ArrayBuffer`): The [`WebAssembly.Memory`](https://developer.mozilla.org/en-US/docs/WebAssembly/JavaScript_interface/Memory) instance to read from.
  * - `ptr` (`number`): The numeric pointer in `buffer` where the C struct is located.
- * - `schema` (`ArrowSchema`): The type of the vector to parse. This is the result of `parseArrowSchema`.
+ * - `schema` (`ArrowSchema`): The type of the vector to read. This is the result of `readSchemaFFI`.
  * - `copy` (`boolean`): If `true`, will _copy_ data across the Wasm boundary, allowing you to delete the copy on the Wasm side. If `false`, the resulting `arrow.Vector` objects will be _views_ on Wasm memory. This requires careful usage as the arrays will become invalid if the memory region in Wasm changes.
  *
  */
-export function parseArrowArray(
+export function readArrayFFI(
   buffer: ArrayBuffer,
   ptr: number,
   schema: ArrowSchema,
@@ -68,7 +68,7 @@ export function parseArrowArray(
   const ptrToChildrenPtrs = dataView.getUint32(ptr + 44, true);
   const children: ArrowArray[] = new Array(Number(nChildren));
   for (let i = 0; i < nChildren; i++) {
-    children[i] = parseArrowArray(
+    children[i] = readArrayFFI(
       buffer,
       dataView.getUint32(ptrToChildrenPtrs + i * 4, true),
       schema.children[i],

--- a/src/ffi/array/write.ts
+++ b/src/ffi/array/write.ts
@@ -1,0 +1,100 @@
+/**
+ * NOTE: all of the functions in this file take a `WebAssembly.Memory` object as
+ * input, not an `ArrayBuffer` object. This is because when a `Memory` instance
+ * grows, its `buffer` is detached!!
+ *
+ * So any time you call `malloc`, you cannot use any old
+ * `WebAssembly.Memory.buffer` instances!
+ *
+ * https://developer.mozilla.org/en-US/docs/WebAssembly/JavaScript_interface/Memory/grow#detachment_upon_growing
+ */
+
+import { ArrowArray } from "../../nanoarrow";
+import { Malloc } from "../../types";
+import { writeUint32Array } from "../../util";
+
+const ARROW_ARRAY_STRUCT_BYTE_SIZE = 60;
+
+/**
+ * Write an `ArrowArray` object into WebAssembly memory according to Arrow C
+ * Data Interface
+ *
+ * - `array`: The array to write.
+ * - `buffer`: The WebAssembly memory space in which to write the array.
+ * - `malloc`: A function that reserves WebAssembly memory. The function should
+ *   take one argument, the length of the buffer to reserve, and return one
+ *   number, the numeric pointer within the memory space marking the beginning
+ *   of this array.
+ *
+ * @return The numeric pointer within `buffer` where the `ArrowArray` C Data Interface struct is located.
+ */
+export function writeArrayFFI(
+  array: ArrowArray,
+  memory: WebAssembly.Memory,
+  malloc: Malloc
+): number {
+  const bufferPtrs = new Uint32Array(array.buffers.length);
+  for (let i = 0; i < bufferPtrs.length; i++) {
+    const buffer = array.buffers[i];
+    const bufferPtr = writeBuffer(buffer, memory, malloc);
+    bufferPtrs[i] = bufferPtr;
+  }
+  const ptrToBufferPtrs = writeUint32Array(bufferPtrs, memory, malloc);
+
+  const childrenPtrs = new Uint32Array(array.children.length);
+  for (let i = 0; i < array.children.length; i++) {
+    const child = array.children[i];
+    const childPtr = writeArrayFFI(child, memory, malloc);
+    childrenPtrs[i] = childPtr;
+  }
+  const ptrToChildrenPtrs = writeUint32Array(childrenPtrs, memory, malloc);
+
+  let dictionaryPtr = 0;
+  if (array.dictionary !== null) {
+    dictionaryPtr = writeArrayFFI(array.dictionary, memory, malloc);
+  }
+
+  // Write the actual struct
+  const arrayStructPtr = malloc(ARROW_ARRAY_STRUCT_BYTE_SIZE);
+  const destinationInt64View = new BigInt64Array(
+    memory.buffer,
+    arrayStructPtr,
+    ARROW_ARRAY_STRUCT_BYTE_SIZE
+  );
+  destinationInt64View[0] = BigInt(array.length);
+  destinationInt64View[1] = BigInt(array.nullCount);
+  destinationInt64View[2] = BigInt(array.offset);
+  destinationInt64View[3] = BigInt(array.buffers.length);
+  destinationInt64View[4] = BigInt(array.children.length);
+
+  const destinationInt32View = new Int32Array(
+    memory.buffer,
+    arrayStructPtr + 40,
+    ARROW_ARRAY_STRUCT_BYTE_SIZE - 40
+  );
+  destinationInt32View[0] = ptrToBufferPtrs;
+  destinationInt32View[1] = ptrToChildrenPtrs;
+  destinationInt32View[2] = dictionaryPtr;
+  // TODO: this sets the release callback to the null pointer.
+  // I assume this will probably break in the wasm side, and we'll need to find
+  // a workaround
+  destinationInt32View[3] = 0;
+  destinationInt32View[4] = 0;
+
+  return arrayStructPtr;
+}
+
+function writeBuffer(
+  buffer: Uint8Array | null,
+  memory: WebAssembly.Memory,
+  malloc: Malloc
+): number {
+  if (buffer === null || buffer.byteLength === 0) {
+    return 0;
+  }
+
+  const ptr = malloc(buffer.length);
+  const destinationView = new Uint8Array(memory.buffer, ptr, buffer.length);
+  destinationView.set(buffer);
+  return ptr;
+}

--- a/src/ffi/index.ts
+++ b/src/ffi/index.ts
@@ -1,1 +1,2 @@
-export { parseArrowSchema } from "./schema";
+export { readSchemaFFI, writeSchemaFFI } from "./schema";
+export { readArrayFFI, writeArrayFFI } from "./array";

--- a/src/ffi/index.ts
+++ b/src/ffi/index.ts
@@ -1,0 +1,1 @@
+export { parseArrowSchema } from "./schema";

--- a/src/ffi/schema.ts
+++ b/src/ffi/schema.ts
@@ -1,0 +1,103 @@
+import { ArrowSchema } from "../nanoarrow/schema";
+
+const UTF8_DECODER = new TextDecoder("utf-8");
+
+/**
+ * Parse an [`ArrowSchema`](https://arrow.apache.org/docs/format/CDataInterface.html#the-arrowschema-structure) C FFI struct into an `ArrowSchema` instance.
+ *
+ * This always copies from the underlying C FFI struct.
+ *
+ * - `buffer` (`ArrayBuffer`): The [`WebAssembly.Memory`](https://developer.mozilla.org/en-US/docs/WebAssembly/JavaScript_interface/Memory) instance to read from.
+ * - `ptr` (`number`): The numeric pointer in `buffer` where the C struct is located.
+ */
+export function parseArrowSchema(
+  buffer: ArrayBuffer,
+  ptr: number
+): ArrowSchema {
+  const dataView = new DataView(buffer);
+
+  const formatPtr = dataView.getUint32(ptr, true);
+  const formatString = parseNullTerminatedString(dataView, formatPtr);
+
+  const namePtr = dataView.getUint32(ptr + 4, true);
+  const name = parseNullTerminatedString(dataView, namePtr);
+
+  const metadataPtr = dataView.getUint32(ptr + 8, true);
+  const metadata = parseMetadata(dataView, metadataPtr);
+
+  // Extra 4 to be 8-byte aligned
+  const flags = dataView.getBigInt64(ptr + 16, true);
+  const nChildren = dataView.getBigInt64(ptr + 24, true);
+
+  const ptrToChildrenPtrs = dataView.getUint32(ptr + 32, true);
+  const childrenFields: ArrowSchema[] = new Array(Number(nChildren));
+  for (let i = 0; i < nChildren; i++) {
+    childrenFields[i] = parseArrowSchema(
+      buffer,
+      dataView.getUint32(ptrToChildrenPtrs + i * 4, true)
+    );
+  }
+
+  return {
+    format: formatString,
+    name,
+    metadata,
+    flags,
+    children: childrenFields,
+    dictionary: null,
+  };
+}
+
+/** Parse a null-terminated C-style string */
+function parseNullTerminatedString(
+  dataView: DataView,
+  ptr: number,
+  maxBytesToRead: number = Infinity
+): string {
+  const maxPtr = Math.min(ptr + maxBytesToRead, dataView.byteLength);
+  let end = ptr;
+  while (end < maxPtr && dataView.getUint8(end) !== 0) {
+    end += 1;
+  }
+
+  return UTF8_DECODER.decode(new Uint8Array(dataView.buffer, ptr, end - ptr));
+}
+
+/**
+ * Parse field metadata
+ *
+ * The metadata format is described here:
+ * https://arrow.apache.org/docs/format/CDataInterface.html#c.ArrowSchema.metadata
+ */
+function parseMetadata(
+  dataView: DataView,
+  ptr: number
+): Map<string, string> | null {
+  const numEntries = dataView.getInt32(ptr, true);
+  if (numEntries === 0) {
+    return null;
+  }
+
+  const metadata: Map<string, string> = new Map();
+
+  ptr += 4;
+  for (let i = 0; i < numEntries; i++) {
+    const keyByteLength = dataView.getInt32(ptr, true);
+    ptr += 4;
+    const key = UTF8_DECODER.decode(
+      new Uint8Array(dataView.buffer, ptr, keyByteLength)
+    );
+    ptr += keyByteLength;
+
+    const valueByteLength = dataView.getInt32(ptr, true);
+    ptr += 4;
+    const value = UTF8_DECODER.decode(
+      new Uint8Array(dataView.buffer, ptr, valueByteLength)
+    );
+    ptr += valueByteLength;
+
+    metadata.set(key, value);
+  }
+
+  return metadata;
+}

--- a/src/ffi/schema/index.ts
+++ b/src/ffi/schema/index.ts
@@ -1,0 +1,2 @@
+export { readSchemaFFI } from "./read";
+export { writeSchemaFFI } from "./write";

--- a/src/ffi/schema/read.ts
+++ b/src/ffi/schema/read.ts
@@ -1,4 +1,4 @@
-import { ArrowSchema } from "../nanoarrow/schema";
+import { ArrowSchema } from "../../nanoarrow/schema";
 
 const UTF8_DECODER = new TextDecoder("utf-8");
 
@@ -10,7 +10,7 @@ const UTF8_DECODER = new TextDecoder("utf-8");
  * - `buffer` (`ArrayBuffer`): The [`WebAssembly.Memory`](https://developer.mozilla.org/en-US/docs/WebAssembly/JavaScript_interface/Memory) instance to read from.
  * - `ptr` (`number`): The numeric pointer in `buffer` where the C struct is located.
  */
-export function parseArrowSchema(
+export function readSchemaFFI(
   buffer: ArrayBuffer,
   ptr: number
 ): ArrowSchema {
@@ -32,7 +32,7 @@ export function parseArrowSchema(
   const ptrToChildrenPtrs = dataView.getUint32(ptr + 32, true);
   const childrenFields: ArrowSchema[] = new Array(Number(nChildren));
   for (let i = 0; i < nChildren; i++) {
-    childrenFields[i] = parseArrowSchema(
+    childrenFields[i] = readSchemaFFI(
       buffer,
       dataView.getUint32(ptrToChildrenPtrs + i * 4, true)
     );

--- a/src/ffi/schema/write.ts
+++ b/src/ffi/schema/write.ts
@@ -1,0 +1,116 @@
+/**
+ * NOTE: all of the functions in this file take a `WebAssembly.Memory` object as
+ * input, not an `ArrayBuffer` object. This is because when a `Memory` instance
+ * grows, its `buffer` is detached!!
+ *
+ * So any time you call `malloc`, you cannot use any old
+ * `WebAssembly.Memory.buffer` instances!
+ *
+ * https://developer.mozilla.org/en-US/docs/WebAssembly/JavaScript_interface/Memory/grow#detachment_upon_growing
+ */
+
+import { ArrowSchema } from "../../nanoarrow";
+import { Malloc } from "../../types";
+import { writeUint32Array } from "../../util";
+
+const UTF8_ENCODER = new TextEncoder();
+const ARROW_SCHEMA_STRUCT_BYTE_SIZE = 48;
+
+/**
+ * Write an `ArrowSchema` object into WebAssembly memory according to Arrow C
+ * Data Interface
+ *
+ * - `schema`: The `ArrowSchema` object to write.
+ * - `buffer`: The WebAssembly memory space in which to write the array.
+ * - `malloc`: A function that reserves WebAssembly memory. The function should
+ *   take one argument, the length of the buffer to reserve, and return one
+ *   number, the numeric pointer within the memory space marking the beginning
+ *   of this array.
+ *
+ * @return The numeric pointer within `buffer` where the `ArrowSchema` C Data Interface struct is located.
+ */
+export function writeSchemaFFI(
+  schema: ArrowSchema,
+  memory: WebAssembly.Memory,
+  malloc: Malloc
+): number {
+  const formatPtr = writeNullTerminatedString(schema.format, memory, malloc);
+  const namePtr = writeNullTerminatedString(schema.name, memory, malloc);
+  // TODO: write metadata
+  const metadataPtr = 0;
+
+  const childrenPtrs = new Uint32Array(schema.children.length);
+  for (let i = 0; i < schema.children.length; i++) {
+    const child = schema.children[i];
+    const childPtr = writeSchemaFFI(child, memory, malloc);
+    childrenPtrs[i] = childPtr;
+  }
+  const ptrToChildrenPtrs = writeUint32Array(childrenPtrs, memory, malloc);
+
+  let dictionaryPtr = 0;
+  if (schema.dictionary !== null) {
+    dictionaryPtr = writeSchemaFFI(schema.dictionary, memory, malloc);
+  }
+
+  const schemaStructPtr = malloc(ARROW_SCHEMA_STRUCT_BYTE_SIZE);
+  const dstDataView = new DataView(
+    memory.buffer,
+    schemaStructPtr,
+    ARROW_SCHEMA_STRUCT_BYTE_SIZE
+  );
+  dstDataView.setUint32(0, formatPtr, true);
+  dstDataView.setUint32(4, namePtr, true);
+  dstDataView.setUint32(8, metadataPtr, true);
+  dstDataView.setBigInt64(16, schema.flags, true);
+  dstDataView.setBigInt64(24, BigInt(schema.children.length), true);
+  dstDataView.setUint32(32, ptrToChildrenPtrs, true);
+  dstDataView.setUint32(36, dictionaryPtr, true);
+
+  // TODO: this sets the release callback to the null pointer.
+  // I assume this will probably break in the wasm side, and we'll need to find
+  // a workaround
+  dstDataView.setUint32(40, 0, true);
+  dstDataView.setUint32(44, 0, true);
+
+  return schemaStructPtr;
+}
+
+/**
+ * Write a null-terminated string into WebAssembly memory
+ */
+function writeNullTerminatedString(
+  s: string,
+  memory: WebAssembly.Memory,
+  malloc: Malloc
+): number {
+  // TODO(perf): Right now we're doing an _exact_ malloc by first encoding the
+  // string into a standalone Uint8Array, and then malloc-ing room for that
+  // exact length. This isn't ideal for performance, because we're making a
+  // superfluous copy of the string.
+  //
+  // Instead, the TextEncoder has an `encodeInto` API, which is ideal for
+  // writing strings directly into Wasm memory. The drawback is that you don't
+  // necessarily know the length of a string, and you have to follow some
+  // heuristics.
+  //
+  // In the Arrow case, the only large string that we may have is the field
+  // metadata, so this extra copy should have relatively low perf impacts
+  //
+  // This whole page is great:
+  // https://developer.mozilla.org/en-US/docs/Web/API/TextEncoder/encodeInto
+
+  const utf8Buffer = UTF8_ENCODER.encode(s);
+
+  // + 1 because null-terminated
+  const byteLength = utf8Buffer.length + 1;
+  const ptr = malloc(byteLength);
+  const destinationView = new Uint8Array(memory.buffer, ptr, byteLength);
+
+  // Copy encoded string
+  destinationView.set(utf8Buffer);
+
+  // Set null termination
+  destinationView[byteLength - 1] = 0;
+
+  return ptr;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,10 @@
 export { parseVector } from "./vector";
 export { parseField } from "./field";
 export { parseRecordBatch } from "./record-batch";
+export {
+  readArrayFFI,
+  readSchemaFFI,
+  writeArrayFFI,
+  writeSchemaFFI,
+} from "./ffi";
+export { ArrowArray, ArrowSchema } from "./nanoarrow";

--- a/src/nanoarrow/array.ts
+++ b/src/nanoarrow/array.ts
@@ -1,0 +1,65 @@
+export interface ArrowArray {
+  /**
+   * The logical length of the array (i.e. its number of items).
+   */
+  length: number;
+
+  /**
+   * The number of null items in the array. MAY be -1 if not yet computed.
+   */
+  nullCount: number;
+
+  /**
+   * The logical offset inside the array (i.e. the number of items from the physical start of the
+   * buffers). MUST be 0 or positive.
+   */
+  offset: number;
+
+  /**
+   * The number of physical buffers backing this array. The number of buffers is a function of the
+   * data type, as described in the [Columnar format
+   * specification](https://arrow.apache.org/docs/format/Columnar.html#format-columnar).
+   *
+   * Buffers of children arrays are not included.
+   */
+  nBuffers: number;
+
+  /**
+   * The number of children this array has. The number of children is a function of the data type,
+   * as described in the [Columnar format
+   * specification](https://arrow.apache.org/docs/format/Columnar.html#format-columnar).
+   */
+  nChildren: number;
+
+  /**
+   * An array of buffers backing this array. There must be `n_buffers` objects.
+   *
+   * The producer MUST ensure that each contiguous buffer is large enough to represent length +
+   * offset values encoded according to the Columnar format specification.
+   *
+   * The buffers may be `null` instead of a `Uint8Array` only in two situations:
+   *
+   * 1. for the null bitmap buffer, if `null_count` is 0;
+   * 2. for any buffer, if the size in bytes of the corresponding buffer would be 0.
+   *
+   * Buffers of children arrays are not included.
+   *
+   * A Uint8Array is stored instead of ArrayBuffers so that this `ArrowArray` may be a view on
+   * external WebAssembly memory.
+   */
+  buffers: (Uint8Array | null)[];
+
+  /**
+   * An array of `ArrowArray` objects representing the children arrays of this array. There must be
+   * `n_children` pointers.
+   */
+  children: ArrowArray[];
+
+  /**
+   * An `ArrowArray` with the underlying array of dictionary values.
+   *
+   * MUST be present if the ArrowArray represents a dictionary-encoded array. MUST be `null`
+   * otherwise.
+   */
+  dictionary: ArrowArray | null;
+}

--- a/src/nanoarrow/array.ts
+++ b/src/nanoarrow/array.ts
@@ -16,22 +16,6 @@ export interface ArrowArray {
   offset: number;
 
   /**
-   * The number of physical buffers backing this array. The number of buffers is a function of the
-   * data type, as described in the [Columnar format
-   * specification](https://arrow.apache.org/docs/format/Columnar.html#format-columnar).
-   *
-   * Buffers of children arrays are not included.
-   */
-  // nBuffers: number;
-
-  /**
-   * The number of children this array has. The number of children is a function of the data type,
-   * as described in the [Columnar format
-   * specification](https://arrow.apache.org/docs/format/Columnar.html#format-columnar).
-   */
-  // nChildren: number;
-
-  /**
    * An array of buffers backing this array. There must be `n_buffers` objects.
    *
    * The producer MUST ensure that each contiguous buffer is large enough to represent length +

--- a/src/nanoarrow/array.ts
+++ b/src/nanoarrow/array.ts
@@ -22,14 +22,14 @@ export interface ArrowArray {
    *
    * Buffers of children arrays are not included.
    */
-  nBuffers: number;
+  // nBuffers: number;
 
   /**
    * The number of children this array has. The number of children is a function of the data type,
    * as described in the [Columnar format
    * specification](https://arrow.apache.org/docs/format/Columnar.html#format-columnar).
    */
-  nChildren: number;
+  // nChildren: number;
 
   /**
    * An array of buffers backing this array. There must be `n_buffers` objects.

--- a/src/nanoarrow/index.ts
+++ b/src/nanoarrow/index.ts
@@ -1,0 +1,2 @@
+export { ArrowArray } from "./array";
+export { ArrowSchema } from "./schema";

--- a/src/nanoarrow/schema.ts
+++ b/src/nanoarrow/schema.ts
@@ -50,9 +50,9 @@ export interface ArrowSchema {
    * but in the `children` structures.
    */
   format: string;
-  name: ArrowString | null;
+  name: string;
   metadata: ArrowString | Map<string, string> | null;
-  flags: number | bigint;
+  flags: bigint;
   children: ArrowSchema[];
   dictionary: ArrowSchema | null;
 }

--- a/src/nanoarrow/schema.ts
+++ b/src/nanoarrow/schema.ts
@@ -1,51 +1,41 @@
 type ArrowString = string | Uint8Array;
 
-export enum ArrowType {
-  NONE = 0 /** The default placeholder type */,
-  Null = 1 /** A NULL type having no physical storage */,
-  Int = 2 /** Signed or unsigned 8, 16, 32, or 64-bit little-endian integer */,
-  Float = 3 /** 2, 4, or 8-byte floating point value */,
-  Binary = 4 /** Variable-length bytes (no guarantee of UTF8-ness) */,
-  Utf8 = 5 /** UTF8 variable-length string as List<Char> */,
-  Bool = 6 /** Boolean as 1 bit, LSB bit-packed ordering */,
-  Decimal = 7 /** Precision-and-scale-based decimal type. Storage type depends on the parameters. */,
-  Date = 8 /** int32_t days or int64_t milliseconds since the UNIX epoch */,
-  Time = 9 /** Time as signed 32 or 64-bit integer, representing either seconds, milliseconds, microseconds, or nanoseconds since midnight since midnight */,
-  Timestamp = 10 /** Exact timestamp encoded with int64 since UNIX epoch (Default unit millisecond) */,
-  Interval = 11 /** YEAR_MONTH or DAY_TIME interval in SQL style */,
-  List = 12 /** A list of some logical data type */,
-  Struct = 13 /** Struct of logical types */,
-  Union = 14 /** Union of logical types */,
-  FixedSizeBinary = 15 /** Fixed-size binary. Each value occupies the same number of bytes */,
-  FixedSizeList = 16 /** Fixed-size list. Each value occupies the same number of bytes */,
-  Map = 17 /** Map of named logical types */,
-
-  Dictionary = -1 /** Dictionary aka Category type */,
-  Int8 = -2,
-  Int16 = -3,
-  Int32 = -4,
-  Int64 = -5,
-  Uint8 = -6,
-  Uint16 = -7,
-  Uint32 = -8,
-  Uint64 = -9,
-  Float16 = -10,
-  Float32 = -11,
-  Float64 = -12,
-  DateDay = -13,
-  DateMillisecond = -14,
-  TimestampSecond = -15,
-  TimestampMillisecond = -16,
-  TimestampMicrosecond = -17,
-  TimestampNanosecond = -18,
-  TimeSecond = -19,
-  TimeMillisecond = -20,
-  TimeMicrosecond = -21,
-  TimeNanosecond = -22,
-  DenseUnion = -23,
-  SparseUnion = -24,
-  IntervalDayTime = -25,
-  IntervalYearMonth = -26,
+/** Types with a static C Data Interface format string */
+export enum ArrowStaticType {
+  Null = "n",
+  Bool = "b",
+  Int8 = "c",
+  Uint8 = "C",
+  Int16 = "s",
+  Uint16 = "S",
+  Int32 = "i",
+  Uint32 = "I",
+  Int64 = "l",
+  Uint64 = "L",
+  Float16 = "e",
+  Float32 = "f",
+  Float64 = "g",
+  Binary = "z",
+  LargeBinary = "Z",
+  String = "u",
+  LargeString = "U",
+  DateDay = "tdD",
+  DateMillisecond = "tdm",
+  TimeSecond = "tts",
+  TimeMillisecond = "ttm",
+  TimeMicrosecond = "ttu",
+  TimeNanosecond = "ttn",
+  DurationSecond = "tDs",
+  DurationMillisecond = "tDm",
+  DurationMicrosecond = "tDu",
+  DurationNanosecond = "tDn",
+  IntervalYearMonth = "tiM",
+  IntervalDayTime = "tiD",
+  IntervalMonthDayNanosecond = "tin",
+  List = "+l",
+  LargeList = "+L",
+  Struct = "+s",
+  Map = "+m",
 }
 
 /**
@@ -65,21 +55,4 @@ export interface ArrowSchema {
   flags: number | bigint;
   children: ArrowSchema[];
   dictionary: ArrowSchema | null;
-}
-
-/**
- * Get the byte length of an array with the given type.
- *
- * @param   {number}     length  [length description]
- * @param   {ArrowType}  type    [type description]
- *
- * @return  {number}             [return description]
- */
-export function getByteLength(length: number, type: ArrowType): number {
-
-}
-
-
-export function getValidityByteLength(length: number): number {
-
 }

--- a/src/nanoarrow/schema.ts
+++ b/src/nanoarrow/schema.ts
@@ -1,0 +1,85 @@
+type ArrowString = string | Uint8Array;
+
+export enum ArrowType {
+  NONE = 0 /** The default placeholder type */,
+  Null = 1 /** A NULL type having no physical storage */,
+  Int = 2 /** Signed or unsigned 8, 16, 32, or 64-bit little-endian integer */,
+  Float = 3 /** 2, 4, or 8-byte floating point value */,
+  Binary = 4 /** Variable-length bytes (no guarantee of UTF8-ness) */,
+  Utf8 = 5 /** UTF8 variable-length string as List<Char> */,
+  Bool = 6 /** Boolean as 1 bit, LSB bit-packed ordering */,
+  Decimal = 7 /** Precision-and-scale-based decimal type. Storage type depends on the parameters. */,
+  Date = 8 /** int32_t days or int64_t milliseconds since the UNIX epoch */,
+  Time = 9 /** Time as signed 32 or 64-bit integer, representing either seconds, milliseconds, microseconds, or nanoseconds since midnight since midnight */,
+  Timestamp = 10 /** Exact timestamp encoded with int64 since UNIX epoch (Default unit millisecond) */,
+  Interval = 11 /** YEAR_MONTH or DAY_TIME interval in SQL style */,
+  List = 12 /** A list of some logical data type */,
+  Struct = 13 /** Struct of logical types */,
+  Union = 14 /** Union of logical types */,
+  FixedSizeBinary = 15 /** Fixed-size binary. Each value occupies the same number of bytes */,
+  FixedSizeList = 16 /** Fixed-size list. Each value occupies the same number of bytes */,
+  Map = 17 /** Map of named logical types */,
+
+  Dictionary = -1 /** Dictionary aka Category type */,
+  Int8 = -2,
+  Int16 = -3,
+  Int32 = -4,
+  Int64 = -5,
+  Uint8 = -6,
+  Uint16 = -7,
+  Uint32 = -8,
+  Uint64 = -9,
+  Float16 = -10,
+  Float32 = -11,
+  Float64 = -12,
+  DateDay = -13,
+  DateMillisecond = -14,
+  TimestampSecond = -15,
+  TimestampMillisecond = -16,
+  TimestampMicrosecond = -17,
+  TimestampNanosecond = -18,
+  TimeSecond = -19,
+  TimeMillisecond = -20,
+  TimeMicrosecond = -21,
+  TimeNanosecond = -22,
+  DenseUnion = -23,
+  SparseUnion = -24,
+  IntervalDayTime = -25,
+  IntervalYearMonth = -26,
+}
+
+/**
+ * A type interface for a JavaScript representation of an `ArrowSchema` struct in the C Data
+ * interface.
+ *
+ * The ArrowSchema structure describes the type and metadata of an exported array or record batch.
+ */
+export interface ArrowSchema {
+  /**
+   * A string describing the data type. If the data type is nested, child types are not encoded here
+   * but in the `children` structures.
+   */
+  format: string;
+  name: ArrowString | null;
+  metadata: ArrowString | Map<string, string> | null;
+  flags: number | bigint;
+  children: ArrowSchema[];
+  dictionary: ArrowSchema | null;
+}
+
+/**
+ * Get the byte length of an array with the given type.
+ *
+ * @param   {number}     length  [length description]
+ * @param   {ArrowType}  type    [type description]
+ *
+ * @return  {number}             [return description]
+ */
+export function getByteLength(length: number, type: ArrowType): number {
+
+}
+
+
+export function getValidityByteLength(length: number): number {
+
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,7 @@
 import { DataType, Field } from "apache-arrow";
 
+export type Malloc = (length: number) => number;
+
 // Redefine the arrow Type enum to include LargeList, LargeBinary, and LargeUtf8
 export enum Type {
   NONE = 0 /** The default placeholder type */,

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,14 @@
+import { Malloc } from "./types";
+
+// TODO: what to do if arr has length 0?
+export function writeUint32Array(
+  arr: Uint32Array,
+  memory: WebAssembly.Memory,
+  malloc: Malloc
+): number {
+  const byteLength = arr.length * Uint32Array.BYTES_PER_ELEMENT;
+  const ptr = malloc(byteLength);
+  const destinationView = new Uint32Array(memory.buffer, ptr, arr.length);
+  destinationView.set(arr);
+  return ptr;
+}

--- a/tests/ffi.test.ts
+++ b/tests/ffi.test.ts
@@ -8,8 +8,7 @@ import { Type } from "../src/types";
 
 wasm.setPanicHook();
 
-// @ts-expect-error
-const WASM_MEMORY: WebAssembly.Memory = wasm.__wasm.memory;
+const WASM_MEMORY: WebAssembly.Memory = wasm._memory();
 
 const TEST_TABLE = loadIPCTableFromDisk("tests/table.arrow");
 const FFI_TABLE = arrowTableToFFI(TEST_TABLE);

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -1,2 +1,3 @@
+import "./write.test";
 import "./ffi.test";
 import "./record-batch.test";

--- a/tests/rust-arrow-ffi/Cargo.lock
+++ b/tests/rust-arrow-ffi/Cargo.lock
@@ -218,6 +218,7 @@ dependencies = [
  "thiserror",
  "wasm-bindgen",
  "wasm-bindgen-test",
+ "web-sys",
 ]
 
 [[package]]

--- a/tests/rust-arrow-ffi/Cargo.toml
+++ b/tests/rust-arrow-ffi/Cargo.toml
@@ -19,6 +19,7 @@ wasm-bindgen = "0.2.63"
 console_error_panic_hook = "0.1.6"
 arrow2 = { version = "0.13.1", features = ["io_ipc"] }
 thiserror = "1.0"
+web-sys = { version = "0.3.64", features = ["console"] }
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.13"

--- a/tests/rust-arrow-ffi/src/ipc.rs
+++ b/tests/rust-arrow-ffi/src/ipc.rs
@@ -1,0 +1,45 @@
+use crate::error::WasmResult;
+use crate::ffi::{FFIArrowChunk, FFIArrowRecordBatch, FFIArrowSchema, FFIArrowTable};
+use arrow2::io::ipc::read::{read_file_metadata, FileReader as IPCFileReader};
+use std::io::Cursor;
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen(js_name = arrowIPCToFFI)]
+pub fn arrow_ipc_to_ffi(arrow_file: &[u8]) -> WasmResult<FFIArrowTable> {
+    // Create IPC reader
+    let mut input_file = Cursor::new(arrow_file);
+    let stream_metadata = read_file_metadata(&mut input_file)?;
+    let arrow_ipc_reader = IPCFileReader::new(input_file, stream_metadata.clone(), None, None);
+    let schema = &stream_metadata.schema;
+
+    let ffi_schema: FFIArrowSchema = schema.into();
+    let mut ffi_chunks: Vec<FFIArrowChunk> = vec![];
+
+    // Iterate over reader chunks, storing each in memory to be used for FFI
+    for maybe_chunk in arrow_ipc_reader {
+        let chunk = maybe_chunk?;
+        ffi_chunks.push(chunk.into());
+    }
+
+    Ok((ffi_schema, ffi_chunks).into())
+}
+
+#[wasm_bindgen(js_name = arrowIPCToFFIRecordBatch)]
+pub fn arrow_ipc_to_ffi_record_batch(
+    arrow_file: &[u8],
+    chunk_idx: Option<usize>,
+) -> WasmResult<FFIArrowRecordBatch> {
+    // Create IPC reader
+    let mut input_file = Cursor::new(arrow_file);
+    let stream_metadata = read_file_metadata(&mut input_file)?;
+    let arrow_ipc_reader = IPCFileReader::new(input_file, stream_metadata.clone(), None, None);
+    let schema = &stream_metadata.schema;
+
+    // Take the nth chunk and store it in memory to be used for FFI
+    if let Some(maybe_chunk) = arrow_ipc_reader.into_iter().nth(chunk_idx.unwrap_or(0)) {
+        let chunk = maybe_chunk?;
+        Ok(FFIArrowRecordBatch::from_chunk(chunk, schema.clone()))
+    } else {
+        Err(JsError::new("Index out of range"))
+    }
+}

--- a/tests/rust-arrow-ffi/src/lib.rs
+++ b/tests/rust-arrow-ffi/src/lib.rs
@@ -1,51 +1,8 @@
 mod error;
 mod ffi;
-use arrow2::io::ipc::read::{read_file_metadata, FileReader as IPCFileReader};
-use std::io::Cursor;
-
-use crate::error::WasmResult;
-use crate::ffi::{FFIArrowChunk, FFIArrowRecordBatch, FFIArrowSchema, FFIArrowTable};
+pub mod ipc;
+pub mod malloc;
 use wasm_bindgen::prelude::*;
-
-#[wasm_bindgen(js_name = arrowIPCToFFI)]
-pub fn arrow_ipc_to_ffi(arrow_file: &[u8]) -> WasmResult<FFIArrowTable> {
-    // Create IPC reader
-    let mut input_file = Cursor::new(arrow_file);
-    let stream_metadata = read_file_metadata(&mut input_file)?;
-    let arrow_ipc_reader = IPCFileReader::new(input_file, stream_metadata.clone(), None, None);
-    let schema = &stream_metadata.schema;
-
-    let ffi_schema: FFIArrowSchema = schema.into();
-    let mut ffi_chunks: Vec<FFIArrowChunk> = vec![];
-
-    // Iterate over reader chunks, storing each in memory to be used for FFI
-    for maybe_chunk in arrow_ipc_reader {
-        let chunk = maybe_chunk?;
-        ffi_chunks.push(chunk.into());
-    }
-
-    Ok((ffi_schema, ffi_chunks).into())
-}
-
-#[wasm_bindgen(js_name = arrowIPCToFFIRecordBatch)]
-pub fn arrow_ipc_to_ffi_record_batch(
-    arrow_file: &[u8],
-    chunk_idx: Option<usize>,
-) -> WasmResult<FFIArrowRecordBatch> {
-    // Create IPC reader
-    let mut input_file = Cursor::new(arrow_file);
-    let stream_metadata = read_file_metadata(&mut input_file)?;
-    let arrow_ipc_reader = IPCFileReader::new(input_file, stream_metadata.clone(), None, None);
-    let schema = &stream_metadata.schema;
-
-    // Take the nth chunk and store it in memory to be used for FFI
-    if let Some(maybe_chunk) = arrow_ipc_reader.into_iter().nth(chunk_idx.unwrap_or(0)) {
-        let chunk = maybe_chunk?;
-        Ok(FFIArrowRecordBatch::from_chunk(chunk, schema.clone()))
-    } else {
-        Err(JsError::new("Index out of range"))
-    }
-}
 
 #[wasm_bindgen(js_name = setPanicHook)]
 pub fn set_panic_hook() {
@@ -56,4 +13,17 @@ pub fn set_panic_hook() {
     // For more details see
     // https://github.com/rustwasm/console_error_panic_hook#readme
     console_error_panic_hook::set_once();
+}
+
+/// Returns a handle to this wasm instance's `WebAssembly.Memory`
+#[wasm_bindgen(js_name = _memory)]
+pub fn memory() -> JsValue {
+    wasm_bindgen::memory()
+}
+
+/// Returns a handle to this wasm instance's `WebAssembly.Table` which is the indirect function
+/// table used by Rust
+#[wasm_bindgen(js_name = _functionTable)]
+pub fn function_table() -> JsValue {
+    wasm_bindgen::function_table()
 }

--- a/tests/rust-arrow-ffi/src/malloc.rs
+++ b/tests/rust-arrow-ffi/src/malloc.rs
@@ -1,0 +1,24 @@
+use wasm_bindgen::prelude::*;
+
+/// Allocate memory into the module's linear memory
+/// and return the offset to the start of the block.
+/// Taken from
+/// https://radu-matei.com/blog/practical-guide-to-wasm-memory/#passing-arrays-to-rust-webassembly-modules
+#[wasm_bindgen]
+pub fn malloc(len: usize) -> *mut u8 {
+    // create a new mutable buffer with capacity `len`
+    let mut buf = Vec::with_capacity(len);
+
+    // take a mutable pointer to the buffer
+    let ptr = buf.as_mut_ptr();
+
+    // take ownership of the memory block and
+    // ensure that its destructor is not
+    // called when the object goes out of scope
+    // at the end of the function
+    std::mem::forget(buf);
+
+    // return the pointer so the runtime
+    // can write data at this offset
+    ptr
+}

--- a/tests/rust-arrow-ffi/src/malloc.rs
+++ b/tests/rust-arrow-ffi/src/malloc.rs
@@ -5,9 +5,12 @@ use wasm_bindgen::prelude::*;
 /// Taken from
 /// https://radu-matei.com/blog/practical-guide-to-wasm-memory/#passing-arrays-to-rust-webassembly-modules
 #[wasm_bindgen]
-pub fn malloc(len: usize) -> *mut u8 {
+pub fn malloc(len: usize) -> *mut u64 {
+    // Note: we "fake" an array of u64, not u8, so that the Rust allocator will align on 8 bytes.
+    let u64_len = (len as f64 / 8.0).ceil() as usize;
+
     // create a new mutable buffer with capacity `len`
-    let mut buf = Vec::with_capacity(len);
+    let mut buf = Vec::with_capacity(u64_len);
 
     // take a mutable pointer to the buffer
     let ptr = buf.as_mut_ptr();

--- a/tests/write.test.ts
+++ b/tests/write.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from "vitest";
+import * as wasm from "rust-arrow-ffi";
+import { arrowTableToFFI, arraysEqual, loadIPCTableFromDisk } from "./utils";
+import {
+  ArrowArray,
+  ArrowSchema,
+  parseField,
+  parseVector,
+  readArrayFFI,
+  readSchemaFFI,
+  writeArrayFFI,
+  writeSchemaFFI,
+} from "../src";
+import { Type } from "../src/types";
+import { ArrowStaticType } from "../src/nanoarrow/schema";
+
+wasm.setPanicHook();
+
+const WASM_MEMORY: WebAssembly.Memory = wasm._memory();
+
+describe("write-read round trip", (t) => {
+  it("test", () => {
+    const values = new Uint8Array([0, 1, 2, 3]);
+    const array: ArrowArray = {
+      length: 4,
+      nullCount: 0,
+      offset: 0,
+      buffers: [null, values],
+      children: [],
+      dictionary: null,
+    };
+    const schema: ArrowSchema = {
+      format: ArrowStaticType.Uint8,
+      name: "hello world!",
+      metadata: null,
+      flags: 0n,
+      children: [],
+      dictionary: null,
+    };
+    const schemaPtr = writeSchemaFFI(schema, WASM_MEMORY, wasm.malloc);
+    const arrayPtr = writeArrayFFI(array, WASM_MEMORY, wasm.malloc);
+
+    const newSchema = readSchemaFFI(WASM_MEMORY.buffer, schemaPtr);
+    const newArray = readArrayFFI(
+      WASM_MEMORY.buffer,
+      arrayPtr,
+      newSchema,
+      true
+    );
+
+    console.log(newSchema);
+    console.log(newArray);
+
+    expect(schema.format).toStrictEqual(newSchema.format);
+    expect(schema.name).toStrictEqual(newSchema.name);
+    expect(schema.metadata).toStrictEqual(newSchema.metadata);
+    expect(schema.flags).toStrictEqual(newSchema.flags);
+
+    expect(array.length).toStrictEqual(newArray.length);
+    expect(array.nullCount).toStrictEqual(newArray.nullCount);
+    expect(array.offset).toStrictEqual(newArray.offset);
+    expect(array.buffers[0]).toStrictEqual(newArray.buffers[0]);
+    expect(array.buffers[1]).toStrictEqual(newArray.buffers[1]);
+  });
+});
+
+describe("write-read round trip", (t) => {
+  it("test", () => {
+    const values = new Uint8Array([0, 1, 2, 3]);
+    const array: ArrowArray = {
+      length: 4,
+      nullCount: 0,
+      offset: 0,
+      buffers: [null, values],
+      children: [],
+      dictionary: null,
+    };
+    const schema: ArrowSchema = {
+      format: ArrowStaticType.Uint8,
+      name: "hello world!",
+      metadata: null,
+      flags: 0n,
+      children: [],
+      dictionary: null,
+    };
+    const schemaPtr = writeSchemaFFI(schema, WASM_MEMORY, wasm.malloc);
+    const arrayPtr = writeArrayFFI(array, WASM_MEMORY, wasm.malloc);
+
+    let wasmArray = wasm.FFIArrowArray.newUnsafe(arrayPtr);
+    let wasmSchema = wasm.FFIArrowField.newUnsafe(schemaPtr);
+
+    wasmArray.import(wasmSchema)
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1978,8 +1978,8 @@ __metadata:
 
 "rust-arrow-ffi@file:./tests/rust-arrow-ffi/pkg/::locator=arrow-js-ffi%40workspace%3A.":
   version: 0.1.0
-  resolution: "rust-arrow-ffi@file:./tests/rust-arrow-ffi/pkg/#./tests/rust-arrow-ffi/pkg/::hash=392a45&locator=arrow-js-ffi%40workspace%3A."
-  checksum: 0fb94a3eef8b7ea1051a45f9a54315f906592646031069dc2740d1f9e7f977f2122f8cd76c12fa24c741d22668fc0a859f6818330d58d89e4f6fde84a3e19abc
+  resolution: "rust-arrow-ffi@file:./tests/rust-arrow-ffi/pkg/#./tests/rust-arrow-ffi/pkg/::hash=5ca7ce&locator=arrow-js-ffi%40workspace%3A."
+  checksum: 7882af0f717cec41d3fc8cda5975f571dc3418a1cadd17923634c3db844779e105b88fa2e1b35a3c422af09d93ad37421ce57a14bbad851086ae75d628b90121
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes https://github.com/kylebarron/arrow-js-ffi/issues/41, closes #42 

### Change list:

- Parse C FFI structs into plain JS objects. Then these intermediate objects can be stored on their own or converted to Arrow JS
- Add writing support for writing the JS representation of these structs into Wasm memory directly, using a `malloc` function exported from wasm.

### Todo:

- [ ] Support converting Arrow JS objects into these structs.
- [ ] Am I going to hit an issue with setting the release callback to the null pointer? It works with arrow2, but that might be implementation specific.