### PR TITLE
Add release callback

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,3 +3,4 @@ export { parseRecordBatch } from "./record-batch";
 export { parseSchema } from "./schema";
 export { parseVector, parseData } from "./vector";
 export { parseTable } from "./table";
+export { releaseSchema } from "./release";

--- a/src/release.ts
+++ b/src/release.ts
@@ -1,0 +1,10 @@
+export function releaseSchema(
+  buffer: ArrayBuffer,
+  ptr: number,
+  funcTable: WebAssembly.Table
+): void {
+  const dataView = new DataView(buffer);
+  const releasePtr = dataView.getUint32(ptr + 40, true);
+  const releaseCallback = funcTable.get(releasePtr);
+  releaseCallback();
+}

--- a/tests/release.test.ts
+++ b/tests/release.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "vitest";
+import * as wasm from "rust-arrow-ffi";
+import { arrowTableToFFI, loadIPCTableFromDisk } from "./utils";
+import { releaseSchema } from "../src";
+
+wasm.setPanicHook();
+
+const WASM_MEMORY = wasm.wasmMemory();
+
+describe("test release", (t) => {
+  it("should release schema", () => {
+    const TEST_TABLE = loadIPCTableFromDisk("tests/table.arrow");
+    const FFI_TABLE = arrowTableToFFI(TEST_TABLE);
+
+    const funcTable = wasm._functionTable();
+    const schemaAddr = FFI_TABLE.schemaAddr(0);
+    releaseSchema(WASM_MEMORY.buffer, schemaAddr, funcTable);
+  });
+});

--- a/tests/rust-arrow-ffi/src/lib.rs
+++ b/tests/rust-arrow-ffi/src/lib.rs
@@ -57,3 +57,16 @@ pub fn set_panic_hook() {
     // https://github.com/rustwasm/console_error_panic_hook#readme
     console_error_panic_hook::set_once();
 }
+
+/// Returns a handle to this wasm instance's `WebAssembly.Memory`
+#[wasm_bindgen(js_name = wasmMemory)]
+pub fn memory() -> JsValue {
+    wasm_bindgen::memory()
+}
+
+/// Returns a handle to this wasm instance's `WebAssembly.Table` which is the indirect function
+/// table used by Rust
+#[wasm_bindgen(js_name = _functionTable)]
+pub fn function_table() -> JsValue {
+    wasm_bindgen::function_table()
+}


### PR DESCRIPTION
It's pretty astounding that this appears to work! Just the fact that it doesn't error is a good sign!

There's a lot of thought still in the memory management between Wasm and JS. We can't call the release callback if we're creating views, because the lifetime of the view might outlive the lifetime of the data. Even if we're copying data to JS, the user might _want_ to do something with their 

